### PR TITLE
Update response status on register_routes.ts

### DIFF
--- a/src/platform/plugins/shared/dashboard/server/api/register_routes.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/register_routes.ts
@@ -161,7 +161,8 @@ export function registerAPIRoutes({
         .for(CONTENT_ID, PUBLIC_API_CONTENT_MANAGEMENT_VERSION);
       let result;
       try {
-        ({ result } = await client.update(req.params.id, attributes, { references }));
+      const { result } = await client.update(req.params.id, attributes, { references });
+      return res.ok({ body: result });
       } catch (e) {
         if (e.isBoom && e.output.statusCode === 404) {
           return res.notFound({
@@ -175,8 +176,6 @@ export function registerAPIRoutes({
         }
         return res.badRequest(e.message);
       }
-
-      return res.created({ body: result });
     }
   );
 


### PR DESCRIPTION
fix: #212673
[Update Response Status Handling]

Why is this needed?
Previously, some responses were returning incorrect status codes (e.g., 200 OK for errors).
This update improves API reliability and error handling consistency.